### PR TITLE
Simplify file contents in roots fileserver test

### DIFF
--- a/tests/integration/files/file/base/testfile
+++ b/tests/integration/files/file/base/testfile
@@ -1,6 +1,6 @@
 Scene 24
 
- 
+
   OLD MAN:  Ah, hee he he ha!
   ARTHUR:  And this enchanter of whom you speak, he has seen the grail?
   OLD MAN:  Ha ha he he he he!


### PR DESCRIPTION
This removes the need to hard code contents in the test. The roots fileserver just reads from the file in binary mode, so we should be able to do the same in the test to confirm the correct behavior of the roots backend.