### PR TITLE
Fixes and improvements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,4 +4,4 @@ PyYAML
 MarkupSafe
 requests>=1.0.0
 distro>=1.0.1
-contextvars; python_version < '3.7'
+contextvars

--- a/requirements/static/ci/py3.5/darwin.txt
+++ b/requirements/static/ci/py3.5/darwin.txt
@@ -112,7 +112,7 @@ cherrypy==17.4.1
 click==7.0                # via geomet
 clustershell==1.8.1
 contextlib2==0.6.0.post1
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.0
 decorator==4.4.2          # via networkx

--- a/requirements/static/ci/py3.5/freebsd.txt
+++ b/requirements/static/ci/py3.5/freebsd.txt
@@ -114,7 +114,7 @@ cherrypy==17.4.1
 click==7.1.2              # via geomet
 clustershell==1.8.3
 contextlib2==0.5.5
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.0
 decorator==4.4.2          # via networkx

--- a/requirements/static/ci/py3.5/linux.txt
+++ b/requirements/static/ci/py3.5/linux.txt
@@ -115,7 +115,7 @@ cherrypy==17.4.1
 click==7.1.1              # via geomet
 clustershell==1.8.3
 contextlib2==0.5.5
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.0
 decorator==4.4.2          # via networkx

--- a/requirements/static/ci/py3.6/darwin.txt
+++ b/requirements/static/ci/py3.6/darwin.txt
@@ -112,7 +112,7 @@ cherrypy==17.4.1
 click==7.0                # via geomet
 clustershell==1.8.1
 contextlib2==0.6.0.post1
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx

--- a/requirements/static/ci/py3.6/freebsd.txt
+++ b/requirements/static/ci/py3.6/freebsd.txt
@@ -114,7 +114,7 @@ cherrypy==17.4.1
 click==7.1.2              # via geomet
 clustershell==1.8.3
 contextlib2==0.5.5
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx

--- a/requirements/static/ci/py3.6/linux.txt
+++ b/requirements/static/ci/py3.6/linux.txt
@@ -115,7 +115,7 @@ cherrypy==17.4.1
 click==7.1.1              # via geomet
 clustershell==1.8.3
 contextlib2==0.5.5
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx

--- a/requirements/static/ci/py3.6/windows.txt
+++ b/requirements/static/ci/py3.6/windows.txt
@@ -25,7 +25,7 @@ cherrypy==18.6.0
 click==7.1.2              # via geomet
 clustershell==1.8.3
 colorama==0.4.1           # via pytest
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 cryptography==3.4.6
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv

--- a/requirements/static/ci/py3.7/darwin.txt
+++ b/requirements/static/ci/py3.7/darwin.txt
@@ -113,6 +113,7 @@ click==7.0                # via geomet
 clustershell==1.8.1
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.6.0.post1
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx
@@ -132,6 +133,7 @@ gitdb==4.0.5
 gitpython==3.1.12
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.15
 importlib-metadata==0.23  # via jsonschema, pluggy, pytest, virtualenv
 iniconfig==1.0.1          # via pytest
 ipaddress==1.0.22         # via kubernetes

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -115,6 +115,7 @@ click==7.1.2              # via geomet
 clustershell==1.8.3
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx
@@ -134,6 +135,7 @@ gitdb==4.0.5              # via gitpython
 gitpython==3.1.12
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.15
 importlib-metadata==0.23  # via jsonschema, pluggy, pytest, virtualenv
 iniconfig==1.0.1          # via pytest
 ipaddress==1.0.22         # via kubernetes

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -116,6 +116,7 @@ click==7.1.1              # via geomet
 clustershell==1.8.3
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx
@@ -135,6 +136,7 @@ gitdb==4.0.5              # via gitpython
 gitpython==3.1.12
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.15
 importlib-metadata==0.23  # via jsonschema, pluggy, pytest, virtualenv
 iniconfig==1.0.1          # via pytest
 ipaddress==1.0.22         # via kubernetes

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -24,6 +24,7 @@ cherrypy==18.6.0
 click==7.1.2              # via geomet
 clustershell==1.8.3
 colorama==0.4.1           # via pytest
+contextvars==2.4
 cryptography==3.4.6
 decorator==4.4.2          # via networkx
 distlib==0.3.0            # via virtualenv
@@ -42,6 +43,7 @@ gitdb==4.0.5
 gitpython==3.1.13
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.15
 importlib-metadata==0.23  # via jsonschema, pluggy, pytest, virtualenv
 iniconfig==1.0.1          # via pytest
 ioloop==0.1a0

--- a/requirements/static/ci/py3.8/darwin.txt
+++ b/requirements/static/ci/py3.8/darwin.txt
@@ -113,6 +113,7 @@ click==7.0                # via geomet
 clustershell==1.8.1
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.6.0.post1
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx
@@ -132,6 +133,7 @@ gitdb==4.0.5
 gitpython==3.1.12
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.15
 iniconfig==1.0.1          # via pytest
 ipaddress==1.0.22         # via kubernetes
 isodate==0.6.0            # via msrest

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -115,6 +115,7 @@ click==7.1.2              # via geomet
 clustershell==1.8.3
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx
@@ -134,6 +135,7 @@ gitdb==4.0.5              # via gitpython
 gitpython==3.1.12
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.15
 iniconfig==1.0.1          # via pytest
 ipaddress==1.0.22         # via kubernetes
 isodate==0.6.0            # via msrest

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -116,6 +116,7 @@ click==7.1.1              # via geomet
 clustershell==1.8.3
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx
@@ -135,6 +136,7 @@ gitdb==4.0.5              # via gitpython
 gitpython==3.1.12
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.15
 iniconfig==1.0.1          # via pytest
 ipaddress==1.0.22         # via kubernetes
 isodate==0.6.0            # via msrest

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -113,6 +113,7 @@ click==7.0                # via geomet
 clustershell==1.8.1
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.6.0.post1
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx
@@ -132,6 +133,7 @@ gitdb==4.0.5
 gitpython==3.1.12
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.15
 iniconfig==1.0.1          # via pytest
 ipaddress==1.0.22         # via kubernetes
 isodate==0.6.0            # via msrest

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -115,6 +115,7 @@ click==7.1.2              # via geomet
 clustershell==1.8.3
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx
@@ -134,6 +135,7 @@ gitdb==4.0.5              # via gitpython
 gitpython==3.1.12
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.15
 iniconfig==1.0.1          # via pytest
 ipaddress==1.0.22         # via kubernetes
 isodate==0.6.0            # via msrest

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -117,6 +117,7 @@ click==7.1.1              # via geomet
 clustershell==1.8.3
 colorama==0.4.3           # via ciscoconfparse
 contextlib2==0.5.5
+contextvars==2.4
 croniter==0.3.29 ; sys_platform != "win32"
 cryptography==3.3.2
 decorator==4.4.2          # via networkx
@@ -136,6 +137,7 @@ gitdb==4.0.5              # via gitpython
 gitpython==3.1.12
 google-auth==1.6.3        # via kubernetes
 idna==2.8
+immutables==0.15
 iniconfig==1.0.1          # via pytest
 ipaddress==1.0.22         # via kubernetes
 isodate==0.6.0            # via msrest

--- a/requirements/static/pkg/py3.5/darwin.txt
+++ b/requirements/static/pkg/py3.5/darwin.txt
@@ -12,7 +12,7 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 cryptography==3.0
 distro==1.5.0
 gitdb==4.0.5              # via gitpython

--- a/requirements/static/pkg/py3.5/freebsd.txt
+++ b/requirements/static/pkg/py3.5/freebsd.txt
@@ -12,7 +12,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 cryptography==3.0         # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests

--- a/requirements/static/pkg/py3.5/linux.txt
+++ b/requirements/static/pkg/py3.5/linux.txt
@@ -12,7 +12,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 cryptography==3.0         # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests

--- a/requirements/static/pkg/py3.6/darwin.txt
+++ b/requirements/static/pkg/py3.6/darwin.txt
@@ -12,7 +12,7 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 cryptography==3.3.2
 distro==1.5.0
 gitdb==4.0.5              # via gitpython

--- a/requirements/static/pkg/py3.6/freebsd.txt
+++ b/requirements/static/pkg/py3.6/freebsd.txt
@@ -12,7 +12,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests

--- a/requirements/static/pkg/py3.6/linux.txt
+++ b/requirements/static/pkg/py3.6/linux.txt
@@ -12,7 +12,7 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests

--- a/requirements/static/pkg/py3.6/windows.txt
+++ b/requirements/static/pkg/py3.6/windows.txt
@@ -10,7 +10,7 @@ cffi==1.14.5
 chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==18.6.0
-contextvars==2.4 ; python_version < "3.7"
+contextvars==2.4
 cryptography==3.4.6
 distro==1.5.0
 gitdb==4.0.5              # via gitpython

--- a/requirements/static/pkg/py3.7/darwin.txt
+++ b/requirements/static/pkg/py3.7/darwin.txt
@@ -11,11 +11,13 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
+contextvars==2.4
 cryptography==3.3.2
 distro==1.5.0
 gitdb==4.0.5              # via gitpython
 gitpython==3.1.12
 idna==2.8
+immutables==0.15          # via contextvars
 jaraco.functools==2.0     # via cheroot, tempora
 jinja2==2.10.1
 linode-python==1.1.1

--- a/requirements/static/pkg/py3.7/freebsd.txt
+++ b/requirements/static/pkg/py3.7/freebsd.txt
@@ -11,9 +11,11 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
+contextvars==2.4
 cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
+immutables==0.15          # via contextvars
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
 markupsafe==1.1.1

--- a/requirements/static/pkg/py3.7/linux.txt
+++ b/requirements/static/pkg/py3.7/linux.txt
@@ -11,9 +11,11 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
+contextvars==2.4
 cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
+immutables==0.15          # via contextvars
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
 markupsafe==1.1.1

--- a/requirements/static/pkg/py3.7/windows.txt
+++ b/requirements/static/pkg/py3.7/windows.txt
@@ -9,11 +9,13 @@ cffi==1.14.5
 chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==18.6.0
+contextvars==2.4
 cryptography==3.4.6
 distro==1.5.0
 gitdb==4.0.5              # via gitpython
 gitpython==3.1.13
 idna==2.8                 # via requests
+immutables==0.15          # via contextvars
 ioloop==0.1a0
 jaraco.classes==3.2.1     # via jaraco.collections
 jaraco.collections==3.2.0  # via cherrypy

--- a/requirements/static/pkg/py3.8/darwin.txt
+++ b/requirements/static/pkg/py3.8/darwin.txt
@@ -11,11 +11,13 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
+contextvars==2.4
 cryptography==3.3.2
 distro==1.5.0
 gitdb==4.0.5              # via gitpython
 gitpython==3.1.12
 idna==2.8
+immutables==0.15          # via contextvars
 jaraco.functools==2.0     # via cheroot, tempora
 jinja2==2.10.1
 linode-python==1.1.1

--- a/requirements/static/pkg/py3.8/freebsd.txt
+++ b/requirements/static/pkg/py3.8/freebsd.txt
@@ -11,9 +11,11 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
+contextvars==2.4
 cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
+immutables==0.15          # via contextvars
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
 markupsafe==1.1.1

--- a/requirements/static/pkg/py3.8/linux.txt
+++ b/requirements/static/pkg/py3.8/linux.txt
@@ -11,9 +11,11 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
+contextvars==2.4
 cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
+immutables==0.15          # via contextvars
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
 markupsafe==1.1.1

--- a/requirements/static/pkg/py3.9/darwin.txt
+++ b/requirements/static/pkg/py3.9/darwin.txt
@@ -11,11 +11,13 @@ chardet==3.0.4            # via requests
 cheroot==8.3.0            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.6.0.post1  # via cherrypy
+contextvars==2.4
 cryptography==3.3.2
 distro==1.5.0
 gitdb==4.0.5              # via gitpython
 gitpython==3.1.12
 idna==2.8
+immutables==0.15          # via contextvars
 jaraco.functools==2.0     # via cheroot, tempora
 jinja2==2.10.1
 linode-python==1.1.1

--- a/requirements/static/pkg/py3.9/freebsd.txt
+++ b/requirements/static/pkg/py3.9/freebsd.txt
@@ -11,9 +11,11 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
+contextvars==2.4
 cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
+immutables==0.15          # via contextvars
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
 markupsafe==1.1.1

--- a/requirements/static/pkg/py3.9/linux.txt
+++ b/requirements/static/pkg/py3.9/linux.txt
@@ -11,9 +11,11 @@ chardet==3.0.4            # via requests
 cheroot==6.5.4            # via cherrypy
 cherrypy==17.4.1
 contextlib2==0.5.5        # via cherrypy
+contextvars==2.4
 cryptography==3.3.2       # via pyopenssl
 distro==1.5.0
 idna==2.8                 # via requests
+immutables==0.15          # via contextvars
 jaraco.functools==2.0     # via tempora
 jinja2==2.10.1
 markupsafe==1.1.1

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -4,7 +4,6 @@ directories for python loadable code and organizes the code into the
 plugin interfaces used by Salt.
 """
 
-import contextvars
 import copy
 import functools
 import importlib
@@ -44,6 +43,13 @@ from salt.exceptions import LoaderError
 from salt.template import check_render_pipe_str
 from salt.utils import entrypoints
 from salt.utils.decorators import Depends
+
+try:
+    # Try the stdlib C extension first
+    import _contextvars as contextvars
+except ImportError:
+    # Py<3.7
+    import contextvars
 
 log = logging.getLogger(__name__)
 

--- a/salt/loader_context.py
+++ b/salt/loader_context.py
@@ -3,8 +3,14 @@ Manage the context a module loaded by Salt's loader
 """
 import collections.abc
 import contextlib
-import contextvars
 import copy
+
+try:
+    # Try the stdlib C extension first
+    import _contextvars as contextvars
+except ImportError:
+    # Py<3.7
+    import contextvars
 
 DEFAULT_CTX_VAR = "loader_ctxvar"
 


### PR DESCRIPTION
### What does this PR do?
* Always install the `contextvars` backport, even on Py3.7+. Without this change, salt-ssh cannot target systems with Python <= 3.6
* Use salt-factories to handle the container. Don't override default roster