### PR TITLE
Onedir/openssl error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ifeq ($(UNAME_S), darwin)
   SED_OPTS := -i ''
 else
   PY_MAKE_ENV := LDFLAGS="-Wl,--as-needed"
-  PY_CONFIG := --with-openssl=$(TARGET_DIR)/depend/ssl -C
+  PY_CONFIG := --with-openssl=$(TARGET_DIR) -C
   SED_OPTS := -i
 endif
 
@@ -45,7 +45,7 @@ $(TARGET_DIRNAME)/Python-$(PYTHON_VERSION): $(TARGET_DIRNAME)/Python-$(PYTHON_VE
 	cd $(PWD); \
 	touch $@;
 
-$(TARGET_DIR)/bin/python$(PY_SUFFIX):  $(TARGET_DIRNAME)/Python-$(PYTHON_VERSION) $(TARGET_DIR)/depend/ssl/bin/openssl
+$(TARGET_DIR)/bin/python$(PY_SUFFIX):  $(TARGET_DIRNAME)/Python-$(PYTHON_VERSION) $(TARGET_DIR)/bin/openssl
 	cd $(TARGET_DIRNAME)/Python-$(PYTHON_VERSION); \
 	$(PY_MAKE_ENV) ./configure -v --prefix=$(TARGET_DIR) $(PY_CONFIG); \
 	$(PY_MAKE_ENV)  make -j4; \
@@ -74,7 +74,6 @@ $(TARGET_DIR)/.onedir:
 fixlibs:
 	python3 ./pkg/relocate.py
 
-
 $(TARGET_DIR)/install-salt:
 	cp $(PWD)/scripts/install-salt $(SCRIPTS_DIR)/install-salt
 
@@ -96,13 +95,13 @@ salt-$(SALT_VERSION)_$(UNAME_S)_$(ARCH).tar.xz: $(SCRIPTS) $(TARGET_DIR)/install
 
 # <--------- Dependencies --------->
 
-$(TARGET_DIR)/depend/ssl/bin/openssl: $(TARGET_DIRNAME)/openssl-$(OPENSSL_VERSION)
+$(TARGET_DIR)/bin/openssl: $(TARGET_DIRNAME)/openssl-$(OPENSSL_VERSION)
 	cd $(TARGET_DIRNAME)/openssl-$(OPENSSL_VERSION); \
-	./config -Wl,-rpath=$(TARGET_DIR)/depend/ssl/lib shared --openssldir=$(TARGET_DIR)/depend/ssl --prefix=$(TARGET_DIR)/depend/ssl --libdir=lib; \
+	./config -Wl,-rpath=$(TARGET_DIR)/lib shared --openssldir=$(TARGET_DIR) --prefix=$(TARGET_DIR) --libdir=lib; \
 	make; \
 	make install; \
 	cd $(PWD)
-	ldconfig $(TARGET_DIR)/depend/ssl/lib
+	ldconfig $(TARGET_DIR)/lib
 
 $(TARGET_DIRNAME)/openssl-$(OPENSSL_VERSION): $(TARGET_DIRNAME)/openssl-$(OPENSSL_VERSION).tar.gz
 	cd $(TARGET_DIRNAME); \
@@ -115,5 +114,5 @@ $(TARGET_DIRNAME)/openssl-$(OPENSSL_VERSION).tar.gz: $(TARGET_DIR)
 	touch $@
 
 # This is for an easy target to build just this dependency
-openssl: $(TARGET_DIR)/depend/ssl/bin/openssl
-	$(TARGET_DIR)/depend/ssl/bin/openssl version -a
+openssl: $(TARGET_DIR)/bin/openssl
+	$(TARGET_DIR)/bin/openssl version -a

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ salt-$(SALT_VERSION)_$(UNAME_S)_$(ARCH).tar.xz: $(SCRIPTS) $(TARGET_DIR)/install
 
 $(TARGET_DIR)/bin/openssl: $(TARGET_DIRNAME)/openssl-$(OPENSSL_VERSION)
 	cd $(TARGET_DIRNAME)/openssl-$(OPENSSL_VERSION); \
-	./config -Wl,-rpath=$(TARGET_DIR)/lib shared --openssldir=$(TARGET_DIR) --prefix=$(TARGET_DIR) --libdir=lib; \
+	./config -Wl,-rpath='$$ORIGIN/../lib' shared --openssldir=$(TARGET_DIR) --prefix=$(TARGET_DIR) --libdir=lib; \
 	make; \
 	make install; \
 	cd $(PWD)

--- a/pkg/relocate.py
+++ b/pkg/relocate.py
@@ -170,7 +170,7 @@ def handle_elf(path, libs, root=None):
 
         lib_name, location_info = (_.strip() for _ in line.split("=>", 1))
         if location_info == "not found":
-            # XXX This could be considered an error
+            # It is likely something was not compiled correctly
             log.warning("Unable to find library %s linked from %s", lib_name, path)
             continue
 
@@ -182,8 +182,6 @@ def handle_elf(path, libs, root=None):
             continue
 
         if is_in_dir(linked_lib, root):
-            # XXX Validate the rpath of the elf points to this file's location
-            # and if not add it.
             needs_rpath = True
             log.warning("Skip file already within root directory: %s", linked_lib)
         else:
@@ -191,7 +189,6 @@ def handle_elf(path, libs, root=None):
 
             if os.path.exists(relocated_path):
                 log.debug("Relocated library exists: %s", relocated_path)
-                # XXX Check hashes?
             else:
                 log.info("Copy %s to %s", linked_lib, relocated_path)
                 shutil.copy(linked_lib, relocated_path)


### PR DESCRIPTION
### What does this PR do?
Installs openssl into the same location as python so the relative rpath points to the correct location after fixlibs

NOTE: An alternative, possibly better solution, would be to add a `python3 pkg/relocate.py` step on specifically the openssl install location.

### Commits signed with GPG?
Yes